### PR TITLE
進行不能バグ修正

### DIFF
--- a/sStS3/sStS3.html
+++ b/sStS3/sStS3.html
@@ -391,7 +391,7 @@ class BattleScene extends Phaser.Scene {
     this.renderHand();
     this.updateInfo();
     // enemy turn
-    this.scene.pause();
+    // this.scene.pause();
     this.enemyTurn();
   }
 
@@ -413,10 +413,12 @@ class BattleScene extends Phaser.Scene {
       }
     }
     // simulate enemy taking any DOT? (simplified) -> we'll deduct small decay
+    /*
     if(e.tags.includes('recon')){
       // recon applies weak DOT to itself: simulate "time" reduces attacker persistence
       e.hp -= 2;
     }
+    */
     // compute next intent (random small)
     e.intentValue = Math.max(3, e.intentValue + Util.randChoice([-2,0,1]));
     e.intent = Util.randChoice(['attack','attack','attack','weaken']); // bias attack


### PR DESCRIPTION
原因：endTurn関数のenemy turnの処理にthis.scene.pause()でシーン停止が入っていた．
理由不明．
推測：デバッグ用

ついでに，敵がdecayしていく処理を無効化している